### PR TITLE
Fix a segmentation fault when an initial connection attempt fails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 ebin
 *.so
+c_src/hiredis/

--- a/c_src/hierdis_nif.c
+++ b/c_src/hierdis_nif.c
@@ -134,8 +134,9 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         
         if (handle->context != NULL && handle->context->err) 
         {
+            ERL_NIF_TERM error = hierdis_make_error(env, handle->context->err, handle->context->errstr);
             enif_release_resource(handle);
-            return hierdis_make_error(env, handle->context->err, handle->context->errstr);
+            return error;
         }
         else
         {
@@ -177,8 +178,9 @@ static ERL_NIF_TERM connect_unix(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
         
         if (handle->context != NULL && handle->context->err) 
         {
+            ERL_NIF_TERM error = hierdis_make_error(env, handle->context->err, handle->context->errstr);
             enif_release_resource(handle);
-            return hierdis_make_error(env, handle->context->err, handle->context->errstr);
+            return error;
         }
         else
         {


### PR DESCRIPTION
I found a small bug in `connect/2,3` and `connect_unix/1,2`:

`enif_release_resource(handle)` was called right before `handle->context->err` and `handle->context->errstr` were used to generate the error message resulting in a segmentation fault.

As a side note, hierdis works great so far on OS X 10.8.4 and SmartOS joyent_20130629T040542Z.
