### PR TITLE
badarg exception for not list params

### DIFF
--- a/c_src/hierdis_nif.h
+++ b/c_src/hierdis_nif.h
@@ -58,7 +58,7 @@ static ERL_NIF_TERM hierdis_make_error(ErlNifEnv* env, int code, const char* rea
 static ERL_NIF_TERM hierdis_make_binary_from_reply(ErlNifEnv* env, redisReply* r);
 static ERL_NIF_TERM hierdis_make_list_from_reply(ErlNifEnv* env, redisReply* r);
 static ERL_NIF_TERM hierdis_make_response(ErlNifEnv* env, redisReply* r, bool as_copy);
-static void list_to_hiredis_argv(ErlNifEnv* env, ERL_NIF_TERM list, unsigned int argc, const char* argv[], size_t argv_lengths[]);
+static int list_to_hiredis_argv(ErlNifEnv* env, ERL_NIF_TERM list, unsigned int argc, const char* argv[], size_t argv_lengths[]);
 
 static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);;
 static ERL_NIF_TERM connect_unix(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);


### PR DESCRIPTION
Hello. I've found that 'hieredis:command(R, ["SET", "key", 1])' sends 'SET key key' to redis. I think it is much better to throw badarg exception in that case
